### PR TITLE
Create cerberus.yaml

### DIFF
--- a/cerberus.yaml
+++ b/cerberus.yaml
@@ -1,0 +1,25 @@
+name: cerberus
+channels:
+- conda-forge
+- bioconda
+dependencies:
+- python=3.9.0
+- sorted_nearest=0.0.33
+- pip
+- pip:
+- pandas
+- scipy
+- numpy<=1.23
+- seaborn
+- matplotlib
+- tqdm
+- click
+- pybigwig
+- bamread>=0.0.10
+- pyranges>=0.0.71
+- lapa
+- pandarallel
+- swan_vis
+- ternary
+- sklearn
+- sparse


### PR DESCRIPTION
When I try to install with pip, I met conflict to compile sorted_nearest=0.0.33 with Cython, after a lot of troubleshooting, I create a yaml file to install all the dependencies (except cerberus itself). 

Hope that can save some times for others.

